### PR TITLE
Refactored response to new format for calculate, changed tests accord…

### DIFF
--- a/app/backend/src/main/java/com/myproject/controllers/FogIndexController.java
+++ b/app/backend/src/main/java/com/myproject/controllers/FogIndexController.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myproject.utils.FogIndexCalculator;
 
+import com.myproject.models.FogIndexResponse;
+
 @RestController
 @RequestMapping("/api/fog-index")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
@@ -23,13 +25,15 @@ public class FogIndexController {
     private final FogIndexCalculator calculator = new FogIndexCalculator();  //  Use a single instance
 
     @GetMapping("/calculate")
-    public ResponseEntity<Map<String, Object>> calculateFogIndex(@RequestParam String githubZipUrl) {
+    public FogIndexResponse calculateFogIndex(@RequestParam String githubZipUrl) {
         try {
             System.out.println("Received request for: " + githubZipUrl);
             String defaultBranch = calculator.getDefaultBranch(githubZipUrl);
             System.out.println("default branch : "+defaultBranch);
             if (defaultBranch == null) {
-                return ResponseEntity.status(500).body(Collections.singletonMap("error", "Failed to determine default branch"));
+                return new FogIndexResponse(new Date(), Collections.singletonList(
+                    Map.of("error", "Failed to determine default branch")
+                ));
             }
 
             String correctedZipUrl = githubZipUrl.replace("/archive/main.zip", "/archive/refs/heads/" + defaultBranch + ".zip");
@@ -64,14 +68,13 @@ public class FogIndexController {
             saveData(repoList);
             System.out.println(" Saved Data for: " + truncatedRepoName);
             result.put("message", "Calculation successful");
-            return ResponseEntity.ok(result);
+            return new FogIndexResponse(new Date(), Collections.singletonList(result));
 
         } catch (Exception e) {
             System.err.println("Error calculating Fog Index: " + e.getMessage());
-            Map<String, Object> errorResponse = new HashMap<>();
-            errorResponse.put("error", "Failed to process the request");
-            errorResponse.put("details", e.getMessage());
-            return ResponseEntity.status(500).body(errorResponse);
+            return new FogIndexResponse(new Date(), Collections.singletonList(
+                Map.of("error", "Failed to process the request", "details", e.getMessage())
+            ));
         }
     }
 

--- a/app/backend/src/main/java/com/myproject/models/FogIndexResponse.java
+++ b/app/backend/src/main/java/com/myproject/models/FogIndexResponse.java
@@ -1,0 +1,33 @@
+package com.myproject.models;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class FogIndexResponse {
+    private Date timestamp;
+    private List<Map<String, Object>> data;
+
+    public FogIndexResponse() {}
+
+    public FogIndexResponse(Date timestamp, List<Map<String, Object>> data) {
+        this.timestamp = timestamp;
+        this.data = data;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public List<Map<String, Object>> getData() {
+        return data;
+    }
+
+    public void setData(List<Map<String, Object>> data) {
+        this.data = data;
+    }
+}

--- a/app/backend/src/test/java/com/myproject/controllers/FogIndexControllerTest.java
+++ b/app/backend/src/test/java/com/myproject/controllers/FogIndexControllerTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import com.myproject.models.FogIndexResponse;
 
 public class FogIndexControllerTest {
 
@@ -49,16 +49,13 @@ public class FogIndexControllerTest {
         FogIndexController controller = new FogIndexController();
         // URL that doesn’t point to a Git repo
         String dummyUrl = "https://example.com/archive/main.zip";
-
-        ResponseEntity<Map<String, Object>> response = controller.calculateFogIndex(dummyUrl);
-
-        // Expect a 500 error because the URL is invalid
-        assertNotNull(response);
-        assertEquals(500, response.getStatusCodeValue(), 
-            "Expected an HTTP 500 error due to invalid URL");
-        assertNotNull(response.getBody(), "Response body should not be null");
-        assertTrue(response.getBody().containsKey("error"), 
-            "Response body should contain an error key");
+    
+        FogIndexResponse response = controller.calculateFogIndex(dummyUrl);
+    
+        assertNotNull(response, "Response should not be null");
+        assertNotNull(response.getData(), "Response data should not be null");
+        assertTrue(response.getData().get(0).containsKey("error"), 
+            "Response data should contain an error key");
     }
 
     @Test
@@ -82,22 +79,18 @@ public class FogIndexControllerTest {
     void testCalculateFogIndex_SuccessWithRealRepo() {
         FogIndexController controller = new FogIndexController();
         String realRepoUrl = "https://github.com/Mrunal2148/ser516-group-java-2/archive/refs/heads/Period-2.zip";
-
-        ResponseEntity<Map<String, Object>> response = controller.calculateFogIndex(realRepoUrl);
-
-        assertNotNull(response, "Controller returned a null ResponseEntity");
-
-        if (response.getStatusCode() == HttpStatus.OK) {
-            Map<String, Object> body = response.getBody();
-            assertNotNull(body, "Response body should not be null");
-            assertTrue(body.containsKey("fogIndex"), "Body should contain a ‘fogIndex’ key");
-            assertTrue(body.containsKey("message"), "Body should contain a ‘message’ key");
-            assertEquals("Calculation successful", body.get("message"),
-                    "Expected a ‘Calculation successful’ message in the response");
-        } else {
-            fail("Expected a 200 OK, but got " + response.getStatusCode()
-                 + ". Details: " + response.getBody());
-        }
+    
+        FogIndexResponse response = controller.calculateFogIndex(realRepoUrl);
+    
+        assertNotNull(response, "Response should not be null");
+        assertNotNull(response.getData(), "Response data should not be null");
+    
+        Map<String, Object> body = response.getData().get(0);
+        assertNotNull(body, "Response body should not be null");
+        assertTrue(body.containsKey("fogIndex"), "Body should contain a ‘fogIndex’ key");
+        assertTrue(body.containsKey("message"), "Body should contain a ‘message’ key");
+        assertEquals("Calculation successful", body.get("message"),
+                "Expected a ‘Calculation successful’ message in the response");
     }
 
     @Test
@@ -118,12 +111,12 @@ public class FogIndexControllerTest {
     void testCalculateFogIndex_withNonExistentBranch_returnsError() {
         FogIndexController controller = new FogIndexController();
         String bogusBranchUrl = "https://github.com/Mrunal2148/ser516-group-java-2/archive/refs/heads/bogus-branch.zip";
-
-        ResponseEntity<Map<String, Object>> response = controller.calculateFogIndex(bogusBranchUrl);
-
-        assertNotNull(response);
-        assertEquals(500, response.getStatusCodeValue(), "Expected 500 for non-existent branch");
-        assertTrue(response.getBody().containsKey("error"));
+    
+        FogIndexResponse response = controller.calculateFogIndex(bogusBranchUrl);
+    
+        assertNotNull(response, "Response should not be null");
+        assertNotNull(response.getData(), "Response data should not be null");
+        assertTrue(response.getData().get(0).containsKey("error"), "Response data should contain an error key");
     }
 
     @Test


### PR DESCRIPTION
Use this API URL for testing:
http://localhost:8080/api/fog-index/calculate?githubZipUrl=https://github.com/facebook/react/archive/refs/heads/main.zip

Response:
{
  "timestamp": "2025-04-17T22:49:23.134+00:00",
  "data": [
    {
      "fogIndex": 10.9124485303975,
      "complexWords": 72013,
      "totalWords": 438182,
      "totalSentences": 40398,
      "percentageComplexWords": 16.4344952553962,
      "totalFiles": 1875,
      "averageSentenceLength": 10.8466260705976,
      "message": "Calculation successful"
    }
  ]
}